### PR TITLE
Fix "…/core.a not found" error

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -61,7 +61,7 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch}  -DUSB_VID={build.vid} -DUSB_PID={build.pid} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
-recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
+recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm


### PR DESCRIPTION
Hey,

I was having a play getting an Adafruit Flora to send MIDI messages using Arduino IDE v2.3.7, following [these steps](https://learn.adafruit.com/midi-drum-glove/code) (roughly) which use this firmware to talk directly to MIDI over USB.

From debugging the console in verbose mode, there was an error message asking the library author to follow [these instructions](https://arduino.github.io/arduino-cli/1.4/platform-specification/#recipes-to-build-the-corea-archive-file) to change their library. I manually patched the the file on my own computer and it seems to work. I'm not sure if this is the right solution but thought I'd create this here as a reference at least or to start the conversation.

FYI, this was the code I've been running — [examples/flora-midi](https://github.com/robb-j/flora-midi)

Thanks,
Rob